### PR TITLE
Put package name in correct place in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Telemetry.MixProject do
   def project do
     [
       app: :telemetry,
+      name: "Telemetry",
       version: @version,
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
@@ -49,7 +50,6 @@ defmodule Telemetry.MixProject do
   defp docs do
     [
       main: "readme",
-      name: "Telemetry",
       canonical: "http://hexdocs.pm/telemetry",
       source_url: "https://github.com/elixir-telemetry/telemetry",
       source_ref: "v#{@version}",


### PR DESCRIPTION
ExDoc couldn't find package name because it was specified under `docs` and not in the `project` function.