### PR TITLE
Fix mismatching typespec

### DIFF
--- a/lib/telemetry/handler_table.ex
+++ b/lib/telemetry/handler_table.ex
@@ -21,7 +21,7 @@ defmodule Telemetry.HandlerTable do
           [Telemetry.event_name()],
           module,
           function :: atom,
-          config :: map
+          config :: term
         ) :: :ok | {:error, :already_exists}
   def insert(handler_id, event_names, module, function, config) do
     Agent.get_and_update(__MODULE__, fn table ->


### PR DESCRIPTION
According to public APIs, config should be a `term()`